### PR TITLE
Removed obselete version label

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   # fakedsmr
   python-fakedsmr:


### PR DESCRIPTION
The version label used in earlier versions of docker-compose has been deprecated. this tag may be omitted from now on.